### PR TITLE
Fix for plugin to calculate percentage wet, dry and invalid

### DIFF
--- a/deafrica_conflux/drill.py
+++ b/deafrica_conflux/drill.py
@@ -671,7 +671,7 @@ def drill(
         # Force warnings to raise exceptions.
         with warnings.catch_warnings():
             warnings.filterwarnings("error")
-            summary = plugin.summarise(values)
+            summary = plugin.summarise(values, resolution)
         # Convert that summary (a 0d dataset) into a dict.
         summary = dataset_to_dict(summary)
         summaries[oid] = summary

--- a/deafrica_conflux/plugins/waterbodies_timeseries.py
+++ b/deafrica_conflux/plugins/waterbodies_timeseries.py
@@ -1,5 +1,5 @@
-import xarray as xr
 import numpy as np
+import xarray as xr
 
 product_name = "waterbodies"
 version = "0.0.1"
@@ -15,8 +15,8 @@ input_products = {
 def transform(inputs: xr.Dataset) -> xr.Dataset:
     wofl = inputs.water
 
-    clear_and_wet = (wofl == 128)
-    clear_and_dry = (wofl == 0)
+    clear_and_wet = wofl == 128
+    clear_and_dry = wofl == 0
 
     clear = clear_and_wet | clear_and_dry
 
@@ -28,24 +28,24 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
 def summarise(inputs: xr.Dataset, resolution: tuple) -> xr.Dataset:
     """
-    Input to this function is dataset, where the .water array contains 
+    Input to this function is dataset, where the .water array contains
     pixel values for a single polygon
     Values are as follows
         1 = water
         0 = dry
         null = invalid (not wet or dry)
     """
-    
+
     # Area of one pixel in metres squared
     # Use absolute value to remove any negative sign from resolution tuple
     px_area = abs(resolution[0] * resolution[1])
-    
+
     # Start with pixel based calculations, then get areas and percentage
     px_total = float(len(inputs.water))
     px_invalid = inputs.water.isnull().sum()
-    pc_invalid = (px_invalid/px_total)*100.0
-    ar_invalid = px_invalid*px_area
-    
+    pc_invalid = (px_invalid / px_total) * 100.0
+    ar_invalid = px_invalid * px_area
+
     # Set wet and dry values to nan, which will be used if insufficient pixels are observed
     px_wet = float("nan")
     pc_wet = float("nan")
@@ -53,17 +53,17 @@ def summarise(inputs: xr.Dataset, resolution: tuple) -> xr.Dataset:
     px_dry = float("nan")
     pc_dry = float("nan")
     ar_dry = float("nan")
-    
+
     # If the proportion of the waterbody missing is less than 10%, calculate values for wet and dry
     if pc_invalid <= 10.0:
         px_wet = inputs.water.sum()
-        pc_wet = (px_wet/px_total)*100.0
-        ar_wet = px_wet*px_area
-        
+        pc_wet = (px_wet / px_total) * 100.0
+        ar_wet = px_wet * px_area
+
         px_dry = px_total - px_invalid - px_wet
         pc_dry = 100.0 - pc_invalid - pc_wet
-        ar_dry = px_dry*px_area
-       
+        ar_dry = px_dry * px_area
+
     # Return all calculated values
     return xr.Dataset(
         {

--- a/deafrica_conflux/plugins/waterbodies_timeseries.py
+++ b/deafrica_conflux/plugins/waterbodies_timeseries.py
@@ -20,26 +20,61 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
     clear = clear_and_wet | clear_and_dry
 
-    # Set the invalid (not clear) pixels to np.nan.
-    wofl_clear = wofl.where(clear, np.nan)
-    return xr.Dataset({"water": wofl_clear})
+    # Set the invalid (not clear) pixels to np.nan
+    # Remaining values will be 1 if water, 0 if dry
+    wofl_masked = clear_and_wet.where(clear)
+    return xr.Dataset({"water": wofl_masked})
 
 
-def summarise(inputs: xr.Dataset) -> xr.Dataset:
-    pixel_count = inputs.water.size
-
-    valid_count = np.count_nonzero(~np.isnan(inputs.water))
-    invalid_count = np.count_nonzero(np.isnan(inputs.water))
-
-    assert valid_count + invalid_count == pixel_count
-
-    valid_and_dry_count = np.count_nonzero(inputs.water == 0)
-    valid_and_wet_count = np.count_nonzero(inputs.water == 128)
-   
-    valid_and_wet_percentage = (valid_and_wet_count / pixel_count) * 100
-    valid_and_dry_percentage = (valid_and_dry_count / pixel_count) * 100 # noqa F841
-    invalid_percentage = (invalid_count / pixel_count) * 100
-
-    return xr.Dataset({"wet_percentage": valid_and_wet_percentage,
-                       "wet_pixel_count": valid_and_wet_count,
-                       "invalid_percentage": invalid_percentage, })
+def summarise(inputs: xr.Dataset, resolution: tuple) -> xr.Dataset:
+    """
+    Input to this function is dataset, where the .water array contains 
+    pixel values for a single polygon
+    Values are as follows
+        1 = water
+        0 = dry
+        null = invalid (not wet or dry)
+    """
+    
+    # Area of one pixel in metres squared
+    # Use absolute value to remove any negative sign from resolution tuple
+    px_area = abs(resolution[0] * resolution[1])
+    
+    # Start with pixel based calculations, then get areas and percentage
+    px_total = float(len(inputs.water))
+    px_invalid = inputs.water.isnull().sum()
+    pc_invalid = (px_invalid/px_total)*100.0
+    ar_invalid = px_invalid*px_area
+    
+    # Set wet and dry values to nan, which will be used if insufficient pixels are observed
+    px_wet = float("nan")
+    pc_wet = float("nan")
+    ar_wet = float("nan")
+    px_dry = float("nan")
+    pc_dry = float("nan")
+    ar_dry = float("nan")
+    
+    # If the proportion of the waterbody missing is less than 10%, calculate values for wet and dry
+    if pc_invalid <= 10.0:
+        px_wet = inputs.water.sum()
+        pc_wet = (px_wet/px_total)*100.0
+        ar_wet = px_wet*px_area
+        
+        px_dry = px_total - px_invalid - px_wet
+        pc_dry = 100.0 - pc_invalid - pc_wet
+        ar_dry = px_dry*px_area
+       
+    # Return all calculated values
+    return xr.Dataset(
+        {
+            "pc_wet": pc_wet,
+            "px_wet": px_wet,
+            "area_wet_m2": ar_wet,
+            "pc_dry": pc_dry,
+            "px_dry": px_dry,
+            "area_dry_m2": ar_dry,
+            "pc_invalid": pc_invalid,
+            "px_invalid": px_invalid,
+            "area_invalid_m2": ar_invalid,
+        }
+    )


### PR DESCRIPTION
After some local testing and investigation into how the polygon drill code works, I found I needed to update the plugin functions to correctly calculate the percentage, area, and pixel values for each of the wet, dry, and invalid categories.

The way the conflux drill works is that by the time it gets to the summarise step, it should have a single array containing the pixel values for just one polygon. For this product, the values can be 1 for wet, 0 for dry, and np.nan for invalid. 

I have also updated the drill function to use resolution as an argument, which allows the summarise function to return area values, which are more likely to be of value to end users.